### PR TITLE
Include raw values

### DIFF
--- a/library/Octane/Data.hs
+++ b/library/Octane/Data.hs
@@ -1285,3 +1285,10 @@ logos =
     , ("Skyhawks", 263)
     , ("Wolves", 264)
     ] & map (\ (v, k) -> (k, Text.pack v)) & Bimap.fromList
+
+gameModes :: Bimap.Bimap Int Text.Text
+gameModes =
+    [ ("Soccar", 0)
+    , ("Hockey", 1)
+    , ("Hoops", 2)
+    ] & map (\ (v, k) -> (k, Text.pack v)) & Bimap.fromList

--- a/library/Octane/FullReplay.hs
+++ b/library/Octane/FullReplay.hs
@@ -17,6 +17,7 @@ import Prelude ((==), (/=), (&&))
 import qualified Control.DeepSeq as DeepSeq
 import qualified Control.Monad as Monad
 import qualified Data.Aeson as Aeson
+import qualified Data.Bimap as Bimap
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy as ByteString
 import qualified Data.Foldable as Foldable
@@ -25,6 +26,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Data.Version as Version
 import qualified GHC.Generics as Generics
+import qualified Octane.Data as Data
 import qualified Octane.Parser as Parser
 import qualified Octane.Parser.Garage as Garage
 import qualified Octane.Type as Type
@@ -340,10 +342,13 @@ getPropertyValue property = case property of
     Parser.PExplosion a b c -> Aeson.toJSON (a, b, c)
     Parser.PFlaggedInt x y -> Aeson.toJSON (x, y)
     Parser.PFloat x -> Aeson.toJSON x
-    Parser.PGameMode x -> case x of
-        1 -> "Hockey"
-        2 -> "Hoops"
-        _ -> Aeson.String ("Unknown game mode " <> Text.pack (Prelude.show x))
+    Parser.PGameMode gameMode -> Aeson.object
+        [ ("Id", Aeson.toJSON gameMode)
+        , ("Name", Data.gameModes
+            & Bimap.lookup (Prelude.fromIntegral gameMode)
+            & (\ x -> x :: Prelude.Maybe Text.Text)
+            & Aeson.toJSON)
+        ]
     Parser.PInt x -> Aeson.toJSON x
     Parser.PLoadout version body decal wheels rocketTrail antenna topper x y -> Aeson.object
         [ ("Version", Aeson.toJSON version)

--- a/library/Octane/FullReplay.hs
+++ b/library/Octane/FullReplay.hs
@@ -347,12 +347,30 @@ getPropertyValue property = case property of
     Parser.PInt x -> Aeson.toJSON x
     Parser.PLoadout version body decal wheels rocketTrail antenna topper x y -> Aeson.object
         [ ("Version", Aeson.toJSON version)
-        , ("Body", Aeson.toJSON body)
-        , ("Decal", Aeson.toJSON decal)
-        , ("Wheels", Aeson.toJSON wheels)
-        , ("RocketTrail", Aeson.toJSON rocketTrail)
-        , ("Antenna", Aeson.toJSON antenna)
-        , ("Topper", Aeson.toJSON topper)
+        , ("Body", Aeson.object
+            [ ("Id", Aeson.toJSON body)
+            , ("Name", body & Garage.getBody & Aeson.toJSON)
+            ])
+        , ("Decal", Aeson.object
+            [ ("Id", Aeson.toJSON decal)
+            , ("Name", decal & Garage.getDecal & Aeson.toJSON)
+            ])
+        , ("Wheels", Aeson.object
+            [ ("Id", Aeson.toJSON wheels)
+            , ("Name", wheels & Garage.getWheels & Aeson.toJSON)
+            ])
+        , ("RocketTrail", Aeson.object
+            [ ("Id", Aeson.toJSON rocketTrail)
+            , ("Name", rocketTrail & Garage.getRocketTrail & Aeson.toJSON)
+            ])
+        , ("Antenna", Aeson.object
+            [ ("Id", Aeson.toJSON antenna)
+            , ("Name", antenna & Garage.getAntenna & Aeson.toJSON)
+            ])
+        , ("Topper", Aeson.object
+            [ ("Id", Aeson.toJSON topper)
+            , ("Name", topper & Garage.getTopper & Aeson.toJSON)
+            ])
         , ("Unknown1", Aeson.toJSON x)
         , ("Unknown2", Aeson.toJSON y)
         ]

--- a/library/Octane/FullReplay.hs
+++ b/library/Octane/FullReplay.hs
@@ -26,6 +26,7 @@ import qualified Data.Text as Text
 import qualified Data.Version as Version
 import qualified GHC.Generics as Generics
 import qualified Octane.Parser as Parser
+import qualified Octane.Parser.Garage as Garage
 import qualified Octane.Type as Type
 import qualified Prelude
 
@@ -390,8 +391,14 @@ getPropertyValue property = case property of
         [ ("Team", Aeson.toJSON team)
         , ("PrimaryColor", Aeson.toJSON color1)
         , ("AccentColor", Aeson.toJSON color2)
-        , ("PrimaryFinish", Aeson.toJSON finish1)
-        , ("AccentFinish", Aeson.toJSON finish2)
+        , ("PrimaryFinish", Aeson.object
+            [ ("Id", Aeson.toJSON finish1)
+            , ("Name", finish1 & Garage.getFinish & Aeson.toJSON)
+            ])
+        , ("AccentFinish", Aeson.object
+            [ ("Id", Aeson.toJSON finish2)
+            , ("Name", finish2 & Garage.getFinish & Aeson.toJSON)
+            ])
         ]
     Parser.PUniqueId systemId remoteId localId -> Aeson.object
         [ ("System", case systemId of

--- a/library/Octane/Parser.hs
+++ b/library/Octane/Parser.hs
@@ -444,10 +444,8 @@ getTeamPaintProperty = do
     team <- getInt8
     primaryColor <- getInt8
     accentColor <- getInt8
-    primaryFinishId <- getInt32
-    let primaryFinish = Garage.getFinish primaryFinishId
-    accentFinishId <- getInt32
-    let accentFinish = Garage.getFinish accentFinishId
+    primaryFinish <- getInt32
+    accentFinish <- getInt32
     return (PTeamPaint team primaryColor accentColor primaryFinish accentFinish)
 
 getUniqueIdProperty :: Bits.BitGet PropValue
@@ -592,12 +590,7 @@ data PropValue
     | PReservation !Int !SystemId !RemoteId !LocalId !(Maybe Text.Text) !Bool !Bool
     | PRigidBodyState !Bool !(Vector Int) !(Vector Float) !(Maybe (Vector Int)) !(Maybe (Vector Int))
     | PString !Text.Text
-    | PTeamPaint
-        !Int
-        !Int
-        !Int
-        !Garage.Finish
-        !Garage.Finish
+    | PTeamPaint !Int !Int !Int !Int !Int
     | PUniqueId !SystemId !RemoteId !LocalId
     deriving (Eq, Generics.Generic, Show)
 

--- a/library/Octane/Parser.hs
+++ b/library/Octane/Parser.hs
@@ -23,7 +23,6 @@ import qualified GHC.Generics as Generics
 import qualified Octane.Data as Data
 import qualified Octane.Json as Json
 import qualified Octane.Parser.ClassPropertyMap as CPM
-import qualified Octane.Parser.Garage as Garage
 import qualified Octane.Type as Type
 import qualified Text.Printf as Printf
 
@@ -327,7 +326,6 @@ getFloatProperty = do
 getGameModeProperty :: Bits.BitGet PropValue
 getGameModeProperty = do
     x <- Bits.getWord8 2
-    -- 1 is hockey, 2 is hoops
     return (PGameMode x)
 
 getIntProperty :: Bits.BitGet PropValue

--- a/library/Octane/Parser.hs
+++ b/library/Octane/Parser.hs
@@ -350,18 +350,12 @@ getLoadoutOnlineProperty = do
 getLoadoutProperty :: Bits.BitGet PropValue
 getLoadoutProperty = do
     version <- getInt8
-    bodyId <- getInt32
-    let body = Garage.getBody bodyId
-    decalId <- getInt32
-    let decal = Garage.getDecal decalId
-    wheelsId <- getInt32
-    let wheels = Garage.getWheels wheelsId
-    rocketTrailId <- getInt32
-    let rocketTrail = Garage.getRocketTrail rocketTrailId
-    antennaId <- getInt32
-    let antenna = Garage.getAntenna antennaId
-    topperId <- getInt32
-    let topper = Garage.getTopper topperId
+    body <- getInt32
+    decal <- getInt32
+    wheels <- getInt32
+    rocketTrail <- getInt32
+    antenna <- getInt32
+    topper <- getInt32
     g <- getInt32
     h <- if version > 10
         then do
@@ -570,16 +564,7 @@ data PropValue
     | PFloat !Float
     | PGameMode !Word.Word8
     | PInt !Int
-    | PLoadout
-        !Int
-        !Garage.Body
-        !Garage.Decal
-        !Garage.Wheels
-        !Garage.RocketTrail
-        !Garage.Antenna
-        !Garage.Topper
-        !Int
-        !(Maybe Int)
+    | PLoadout !Int !Int !Int !Int !Int !Int !Int !Int !(Maybe Int)
     | PLoadoutOnline !Int !Int !Int !(Maybe Int)
     | PLocation !(Vector Int)
     | PMusicStinger !Bool !Int !Int

--- a/library/Octane/Parser/Garage.hs
+++ b/library/Octane/Parser/Garage.hs
@@ -1,9 +1,6 @@
 module Octane.Parser.Garage where
 
-import Data.Function ((&))
-
 import qualified Data.Bimap as Bimap
-import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import qualified Octane.Data as Data
 
@@ -17,39 +14,28 @@ type Topper = Text.Text
 type Finish = Text.Text
 
 
-getDefaultItem :: String -> Int -> Text.Text
-getDefaultItem itemType itemId =
-    ["Unknown", itemType, show itemId] & unwords & Text.pack
+getBody :: Int -> Maybe Body
+getBody bodyId = Bimap.lookup bodyId Data.bodies
 
 
-getItem :: Bimap.Bimap Int Text.Text -> String -> Int -> Text.Text
-getItem items itemType itemId = items
-    & Bimap.lookup itemId
-    & Maybe.fromMaybe (getDefaultItem itemType itemId)
+getDecal :: Int -> Maybe Decal
+getDecal decalId = Bimap.lookup decalId Data.decals
 
 
-getBody :: Int -> Body
-getBody = getItem Data.bodies "body"
+getWheels :: Int -> Maybe Wheels
+getWheels wheelsId = Bimap.lookup wheelsId Data.wheels
 
 
-getDecal :: Int -> Decal
-getDecal = getItem Data.decals "decal"
+getRocketTrail :: Int -> Maybe RocketTrail
+getRocketTrail rocketTrailId = Bimap.lookup rocketTrailId Data.rocketTrails
 
 
-getWheels :: Int -> Wheels
-getWheels = getItem Data.wheels "wheels"
+getAntenna :: Int -> Maybe Antenna
+getAntenna antennaId = Bimap.lookup antennaId Data.antennas
 
 
-getRocketTrail :: Int -> RocketTrail
-getRocketTrail = getItem Data.rocketTrails "rocket trail"
-
-
-getAntenna :: Int -> Antenna
-getAntenna = getItem Data.antennas "antenna"
-
-
-getTopper :: Int -> Topper
-getTopper = getItem Data.toppers "topper"
+getTopper :: Int -> Maybe Topper
+getTopper topperId = Bimap.lookup topperId Data.toppers
 
 
 getFinish :: Int -> Maybe Finish

--- a/library/Octane/Parser/Garage.hs
+++ b/library/Octane/Parser/Garage.hs
@@ -52,5 +52,5 @@ getTopper :: Int -> Topper
 getTopper = getItem Data.toppers "topper"
 
 
-getFinish :: Int -> Finish
-getFinish = getItem Data.finishes "finish"
+getFinish :: Int -> Maybe Finish
+getFinish finishId = Bimap.lookup finishId Data.finishes


### PR DESCRIPTION
This fixes #12. It changes some values to return both an ID and a name instead of just a name. For example:

``` json
"TAGame.Car_TA:TeamPaint": {
    "Value": {
        "PrimaryFinish": {
            "Name": "Matte",
            "Id": 273
        },
        "Team": 1,
        "AccentFinish": {
            "Name": "Metallic Pearl",
            "Id": 275
        },
        "AccentColor": 83,
        "PrimaryColor": 8
    },
    "Type": "Paint"
}

"TAGame.PRI_TA:ClientLoadout": {
    "Value": {
        "Antenna": {
            "Name": "Jolly Roger",
            "Id": 217
        },
        "Body": {
            "Name": "Octane",
            "Id": 23
        },
        "Wheels": {
            "Name": "Cristiano",
            "Id": 386
        },
        "RocketTrail": {
            "Name": "Flamethrower",
            "Id": 36
        },
        "Unknown1": 0,
        "Topper": {
            "Name": "Pirate's Hat",
            "Id": 235
        },
        "Decal": {
            "Name": "Skulls [Octane]",
            "Id": 304
        },
        "Version": 10,
        "Unknown2": null
    },
    "Type": "Loadout"
}
```
