### PR TITLE
Allow URL arguments

### DIFF
--- a/library/Octane/Main.hs
+++ b/library/Octane/Main.hs
@@ -3,6 +3,8 @@ module Octane.Main (main) where
 import qualified Data.Aeson as Aeson
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy as LazyBytes
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Client.TLS as TLS
 import qualified Octane.Type.Replay as Replay
 import qualified System.Environment as Environment
 
@@ -12,37 +14,64 @@ import qualified System.Environment as Environment
 -- 1.  If no arguments are given, it will read from 'System.IO.stdin' and write
 --     to a JSON object to 'System.IO.stdout'.
 --
--- 2.  If one argument is given, it will assume that argument is a file, read
---     from it, and write a JSON object to 'System.IO.stdout'.
+--     > octane < a.replay > replay.json
+--
+-- 2.  If one argument is given, it will assume that argument is a path to a
+--     replay. Both local and remote (HTTP or HTTPS) paths are supported.
+--     Octane will read from the path and write a JSON object to
+--     'System.IO.stdout'.
+--
+--     > octane a.replay > replay.json
+--
+--     > octane https://media.rocketleaguereplays.com/uploads/replay_files/8D0940554D285C3F45109F85C79396A2.replay > replay.json
 --
 -- 3.  If multiple arguments are given, it will assume that those arguments are
---     files, read from them, and write a JSON array of objects to
+--     paths to replays, read from them, and write a JSON array of objects to
 --     'System.IO.stdout'.
+--
+--     > octane first.replay second.replay > replays.json
 main :: IO ()
 main = do
+    manager <- Client.newManager TLS.tlsManagerSettings
+    TLS.setGlobalManager manager
+
     args <- Environment.getArgs
     case args of
-        [] -> mainWithoutFiles
-        [file] -> mainWithFile file
-        files -> mainWithFiles files
+        [] -> main0
+        [x] -> main1 x
+        xs -> main2 xs
 
 
-mainWithoutFiles :: IO ()
-mainWithoutFiles = do
+main0 :: IO ()
+main0 = do
     LazyBytes.interact (\ input -> do
         let replay = Binary.decode input
         Aeson.encode (replay :: Replay.Replay))
 
 
-mainWithFile :: FilePath -> IO ()
-mainWithFile file = do
-    replay <- Binary.decodeFile file
-    let output = Aeson.encode (replay :: Replay.Replay)
+main1 :: String -> IO ()
+main1 x = do
+    replay <- decode x
+    let output = Aeson.encode replay
     LazyBytes.putStr output
 
 
-mainWithFiles :: [FilePath] -> IO ()
-mainWithFiles files = do
-    replays <- mapM Binary.decodeFile files
-    let output = Aeson.encode (replays :: [Replay.Replay])
+main2 :: [String] -> IO ()
+main2 xs = do
+    replays <- mapM decode xs
+    let output = Aeson.encode replays
     LazyBytes.putStr output
+
+
+decode :: String -> IO Replay.Replay
+decode x = do
+    case Client.parseUrl x of
+        Nothing -> do
+            let file = x
+            Binary.decodeFile file
+        Just request -> do
+            manager <- TLS.getGlobalManager
+            response <- Client.httpLbs request manager
+            let input = Client.responseBody response
+            let replay = Binary.decode input
+            pure replay

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,8 @@ library:
   - containers ==0.5.*
   - data-binary-ieee754 ==0.4.*
   - deepseq ==1.4.*
+  - http-client ==0.4.*
+  - http-client-tls ==0.2.*
   - text ==1.2.*
   - unordered-containers ==0.2.*
   - vector ==0.11.*


### PR DESCRIPTION
This fixes #19.

Note that URLs must include the protocol. So `https://media.rocketleaguereplays.com/...` is valid but just `media.rocketleaguereplays.com/...` is not.
