### PR TITLE
Parse PlayStation names

### DIFF
--- a/library/Octane/Type/Frame.hs
+++ b/library/Octane/Type/Frame.hs
@@ -18,7 +18,6 @@ import qualified GHC.Generics as Generics
 import qualified Octane.Data as Data
 import qualified Octane.Type.Float32 as Float32
 import qualified Octane.Type.Initialization as Initialization
-import qualified Octane.Type.RemoteId as RemoteId
 import qualified Octane.Type.Replication as Replication
 import qualified Octane.Type.State as State
 import qualified Octane.Type.Value as Value
@@ -254,11 +253,7 @@ getValue value = case value of
             2 -> "PlayStation"
             4 -> "Xbox"
             _ -> Aeson.String ("Unknown system " <> StrictText.pack (show systemId)))
-        , ("Remote", case remoteId of
-            RemoteId.SplitscreenId x -> Aeson.toJSON x
-            RemoteId.SteamId x -> Aeson.toJSON x
-            RemoteId.PlayStationId x -> Aeson.toJSON x
-            RemoteId.XboxId x -> Aeson.toJSON x)
+        , ("Remote", Aeson.toJSON remoteId)
         , ("Local", Aeson.toJSON localId)
         ]
 

--- a/library/Octane/Type/RemoteId.hs
+++ b/library/Octane/Type/RemoteId.hs
@@ -19,7 +19,7 @@ import qualified Octane.Type.Word64 as Word64
 data RemoteId
     = SteamId Word64.Word64
     -- ^ A Steam ID.
-    | PlayStationId Text.Text
+    | PlayStationId Text.Text Text.Text
     -- ^ A PlayStation Network ID.
     | SplitscreenId (Maybe Int)
     -- ^ A local splitscreen ID.
@@ -31,9 +31,12 @@ instance DeepSeq.NFData RemoteId where
 
 instance Aeson.ToJSON RemoteId where
     toJSON remoteId = case remoteId of
-        PlayStationId x -> Aeson.object
+        PlayStationId x y -> Aeson.object
             [ "Type" .= ("PlayStation" :: Text.Text)
-            , "Value" .= x
+            , "Value" .= Aeson.object
+                [ "Name" .= x
+                , "Unknown" .= y
+                ]
             ]
         SplitscreenId x -> Aeson.object
             [ "Type" .= ("Splitscreen" :: Text.Text)


### PR DESCRIPTION
This fixes #30. 

Before:

``` json
{
  "Remote": "476c6f7773426c75650000000000000062376762707334000100000000000000",
  "Local": 0,
  "System": "PlayStation"
}
```

After:

``` json
{
  "Remote": {
    "Value": {
      "Unknown": "0x62376762707334000100000000000000",
      "Name": "GlowsBlue"
    },
    "Type": "PlayStation"
  },
  "Local": 0,
  "System": "PlayStation"
}
```

I (obviously) don't know what the "unknown" value is. I tried to decode it as text (Latin-1) but didn't really get anything useful. It may be a unique integral ID or something. 

Also there is some unfortunate duplication between the remote ID's type and the unique ID's system. I don't mind it because it makes my code cleaner and it's a good sanity check. 
