### PR TITLE
Add a compressed word type

### DIFF
--- a/library/Octane/Type/CompressedWord.hs
+++ b/library/Octane/Type/CompressedWord.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Octane.Type.CompressedWord (CompressedWord(..), fromCompressedWord) where
+
+import Data.Aeson ((.=))
+import Data.Function ((&))
+
+import qualified Control.DeepSeq as DeepSeq
+import qualified Data.Aeson as Aeson
+import qualified Data.Binary.Bits as BinaryBit
+import qualified Data.Binary.Bits.Get as BinaryBit
+import qualified Data.Binary.Bits.Put as BinaryBit
+import qualified Data.Bits as Bits
+import qualified GHC.Generics as Generics
+import qualified Octane.Type.Boolean as Boolean
+
+-- $setup
+-- >>> import qualified Data.Binary.Get as Binary
+-- >>> import qualified Data.Binary.Put as Binary
+
+
+-- | A compressed, unsigned integer. When serialized, the least significant bit
+-- is first. Bits are serialized until the next bit would be greater than the
+-- limit, or the number of bits necessary to reach the limit has been reached,
+-- whichever comes first.
+data CompressedWord = CompressedWord
+    { limit :: Word
+    , value :: Word
+    } deriving (Eq, Generics.Generic, Show)
+
+-- | Abuses the first argument to 'BinaryBit.getBits' as the maximum value.
+--
+-- >>> Binary.runGet (BinaryBit.runBitGet (BinaryBit.getBits 4)) "\x7f" :: CompressedWord
+-- CompressedWord {limit = 4, value = 2}
+--
+-- >>> Binary.runPut (BinaryBit.runBitPut (BinaryBit.putBits 0 (CompressedWord 4 2)))
+-- "\128"
+instance BinaryBit.BinaryBit CompressedWord where
+    getBits n = do
+        let theLimit = fromIntegral n
+        theValue <- getStep theLimit (bitSize theLimit) 0 0
+        pure (CompressedWord theLimit theValue)
+
+    putBits _ compressedWord = do
+        let theLimit = fromIntegral (limit compressedWord)
+        let theValue = fromIntegral (value compressedWord)
+        let maxBits = bitSize theLimit
+        let upper = (2 ^ (maxBits - 1)) - 1
+        let lower = theLimit - upper
+        let numBits = if lower > theValue || theValue > upper
+                then maxBits
+                else maxBits - 1
+        BinaryBit.putWord64be numBits theValue
+
+instance DeepSeq.NFData CompressedWord where
+
+-- | Encoded as an object.
+--
+-- >>> Aeson.encode (CompressedWord 2 1)
+-- "{\"Value\":1,\"Limit\":2}"
+instance Aeson.ToJSON CompressedWord where
+    toJSON compressedWord = Aeson.object
+        [ "Limit" .= limit compressedWord
+        , "Value" .= value compressedWord
+        ]
+
+
+-- | Converts a 'CompressedWord' into any integral value. This is a lossy
+-- conversion because it discards the compressed word's maximum value.
+--
+-- >>> fromCompressedWord (CompressedWord 2 1) :: Int
+-- 1
+fromCompressedWord :: (Integral a) => CompressedWord -> a
+fromCompressedWord compressedWord = compressedWord & value & fromIntegral
+
+
+bitSize :: (Integral a, Integral b) => a -> b
+bitSize x = x & fromIntegral & logBase (2 :: Double) & ceiling
+
+
+getStep :: Word -> Word -> Word -> Word -> BinaryBit.BitGet Word
+getStep theLimit maxBits position theValue = do
+    let x = Bits.shiftL 1 (fromIntegral position)
+    if position < maxBits && theValue + x <= theLimit
+    then do
+        bit <- BinaryBit.getBits 0
+        let newValue = if Boolean.unpack bit then theValue + x else theValue
+        getStep theLimit maxBits (position + 1) newValue
+    else pure theValue

--- a/library/Octane/Type/Initialization.hs
+++ b/library/Octane/Type/Initialization.hs
@@ -2,10 +2,14 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE StrictData #-}
 
-module Octane.Type.Initialization (Initialization(..)) where
+module Octane.Type.Initialization (Initialization(..), getInitialization) where
 
 import qualified Control.DeepSeq as DeepSeq
+import qualified Data.Binary.Bits.Get as BinaryBit
+import qualified Data.Set as Set
+import qualified Data.Text as StrictText
 import qualified GHC.Generics as Generics
+import qualified Octane.Data as Data
 import qualified Octane.Type.Int8 as Int8
 import qualified Octane.Type.Vector as Vector
 
@@ -22,3 +26,15 @@ data Initialization = Initialization
     } deriving (Eq, Generics.Generic, Show)
 
 instance DeepSeq.NFData Initialization where
+
+
+-- | Gets the 'Initialization' for a given class.
+getInitialization :: StrictText.Text -> BinaryBit.BitGet Initialization
+getInitialization className = do
+    location' <- if Set.member className Data.classesWithLocation
+        then fmap Just Vector.getIntVector
+        else pure Nothing
+    rotation' <- if Set.member className Data.classesWithRotation
+        then fmap Just Vector.getInt8Vector
+        else pure Nothing
+    pure Initialization { location = location', rotation = rotation' }

--- a/library/Octane/Type/Replication.hs
+++ b/library/Octane/Type/Replication.hs
@@ -8,6 +8,7 @@ import qualified Control.DeepSeq as DeepSeq
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as StrictText
 import qualified GHC.Generics as Generics
+import qualified Octane.Type.CompressedWord as CompressedWord
 import qualified Octane.Type.Initialization as Initialization
 import qualified Octane.Type.State as State
 import qualified Octane.Type.Value as Value
@@ -18,7 +19,7 @@ import qualified Octane.Type.Value as Value
 -- This cannot be an instance of 'Data.Binary.Bits.BinaryBit' because it
 -- requires out-of-band information (the class property map) to decode.
 data Replication = Replication
-    { actorId :: Word
+    { actorId :: CompressedWord.CompressedWord
     -- ^ The actor's ID.
     , objectName :: StrictText.Text
     -- ^ The name of the actor's object.

--- a/library/Octane/Type/Value.hs
+++ b/library/Octane/Type/Value.hs
@@ -7,6 +7,7 @@ module Octane.Type.Value (Value(..)) where
 import qualified Control.DeepSeq as DeepSeq
 import qualified GHC.Generics as Generics
 import qualified Octane.Type.Boolean as Boolean
+import qualified Octane.Type.CompressedWord as CompressedWord
 import qualified Octane.Type.Float32 as Float32
 import qualified Octane.Type.Int32 as Int32
 import qualified Octane.Type.RemoteId as RemoteId
@@ -88,7 +89,7 @@ data Value
     | VRelativeRotation
         (Vector.Vector Float)
     | VReservation
-        Int
+        CompressedWord.CompressedWord
         Word8.Word8
         RemoteId.RemoteId
         (Maybe Word8.Word8)

--- a/library/Octane/Type/Value.hs
+++ b/library/Octane/Type/Value.hs
@@ -66,7 +66,7 @@ data Value
         Word32.Word32
         (Maybe Word32.Word32)
     | VLoadoutOnline
-        [[(Word32.Word32, Int)]]
+        [[(Word32.Word32, CompressedWord.CompressedWord)]]
     | VLocation
         (Vector.Vector Int)
     | VMusicStinger

--- a/library/Octane/Type/Vector.hs
+++ b/library/Octane/Type/Vector.hs
@@ -2,11 +2,15 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE StrictData #-}
 
-module Octane.Type.Vector (Vector(..)) where
+module Octane.Type.Vector (Vector(..), getIntVector) where
 
 import qualified Control.DeepSeq as DeepSeq
 import qualified Data.Aeson as Aeson
+import qualified Data.Bits as Bits
+import qualified Data.Binary.Bits as BinaryBit
+import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified GHC.Generics as Generics
+import qualified Octane.Type.CompressedWord as CompressedWord
 
 
 -- | Three values packed together. Although the fields are called @x@, @y@, and
@@ -33,3 +37,22 @@ instance (Aeson.ToJSON a) => Aeson.ToJSON (Vector a) where
         , y vector
         , z vector
         ]
+
+
+-- | Gets a 'Vector' full of 'Int's.
+getIntVector :: BinaryBit.BitGet (Vector Int)
+getIntVector = do
+    numBits <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits 19)
+    let bias = Bits.shiftL 1 (numBits + 1)
+    let maxBits = numBits + 2
+    let maxValue = 2 ^ maxBits
+
+    dx <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
+    dy <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
+    dz <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
+
+    pure Vector
+        { x = dx - bias
+        , y = dy - bias
+        , z = dz - bias
+        }

--- a/library/Octane/Type/Vector.hs
+++ b/library/Octane/Type/Vector.hs
@@ -2,7 +2,12 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE StrictData #-}
 
-module Octane.Type.Vector (Vector(..), getFloatVector, getIntVector) where
+module Octane.Type.Vector
+    ( Vector(..)
+    , getFloatVector
+    , getInt8Vector
+    , getIntVector
+    ) where
 
 import qualified Control.DeepSeq as DeepSeq
 import qualified Data.Aeson as Aeson
@@ -10,7 +15,9 @@ import qualified Data.Bits as Bits
 import qualified Data.Binary.Bits as BinaryBit
 import qualified Data.Binary.Bits.Get as BinaryBit
 import qualified GHC.Generics as Generics
+import qualified Octane.Type.Boolean as Boolean
 import qualified Octane.Type.CompressedWord as CompressedWord
+import qualified Octane.Type.Int8 as Int8
 
 
 -- | Three values packed together. Although the fields are called @x@, @y@, and
@@ -63,6 +70,21 @@ getFloat maxValue numBits = do
         let scale = fromIntegral maxBitValue / fromIntegral maxValue
         let invScale = 1.0 / scale
         pure (fromIntegral unscaledValue * invScale)
+
+
+-- | Gets a 'Vector' full of 'Int8's.
+getInt8Vector :: BinaryBit.BitGet (Vector Int8.Int8)
+getInt8Vector = do
+    hasX <- BinaryBit.getBits 0
+    x' <- if Boolean.unpack hasX then BinaryBit.getBits 0 else pure 0
+
+    hasY <- BinaryBit.getBits 0
+    y' <- if Boolean.unpack hasY then BinaryBit.getBits 0 else pure 0
+
+    hasZ <- BinaryBit.getBits 0
+    z' <- if Boolean.unpack hasZ then BinaryBit.getBits 0 else pure 0
+
+    pure Vector { x = x' , y = y' , z = z' }
 
 
 -- | Gets a 'Vector' full of 'Int's.

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -380,7 +380,7 @@ getLoadoutOnlineProperty = do
         innerSize <- getWord8
         Monad.replicateM (innerSize & Word8.unpack & fromIntegral) (do
             x <- getWord32
-            y <- getInt 27
+            y <- BinaryBit.getBits 27
             pure (x, y)))
     pure (Value.VLoadoutOnline values)
 

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -632,9 +632,9 @@ getVector = do
     let bias = Bits.shiftL 1 (numBits + 1)
     let maxBits = numBits + 2
     let maxValue = 2 ^ maxBits
-    dx <- getInt maxValue
-    dy <- getInt maxValue
-    dz <- getInt maxValue
+    dx <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
+    dy <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
+    dz <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxValue)
     pure
         Vector.Vector
         { Vector.x = dx - bias
@@ -706,39 +706,6 @@ getInitialization className = do
         { Initialization.location = location
         , Initialization.rotation = rotation
         }
-
-
-bitSize
-    :: (Integral a)
-    => a -> a
-bitSize x = x & fromIntegral & logBase (2 :: Double) & ceiling
-
-
--- Reads an integer bitwise. The bits of the integer are backwards, so the
--- least significant bit is first. The argument is the maximum value this
--- integer can have. Bits will be read until the next bit would be greater than
--- the maximum value, or the number of bits necessary to reach the maximum
--- value has been reached, whichever comes first.
---
--- For example, if the maximum value is 4 and "11" has been read already,
--- nothing more will be read because another "1" would put the value over the
--- maximum.
-getInt
-    :: Int -> Bits.BitGet Int
-getInt maxValue = do
-    let maxBits = bitSize maxValue
-        go i value = do
-            let x = Bits.shiftL 1 i
-            if i < maxBits && value + x <= maxValue
-                then do
-                    bit <- getBool
-                    let newValue =
-                            if Boolean.unpack bit
-                                then value + x
-                                else value
-                    go (i + 1) newValue
-                else pure value
-    go 0 0
 
 
 getInt32 :: Bits.BitGet Int32.Int32

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -255,7 +255,7 @@ getProp context thing = do
         Nothing -> fail ("could not find property map for class id " ++ show classId)
         Just x -> pure x
     let maxId = props & IntMap.keys & (0 :) & maximum
-    pid <- getPropId maxId
+    pid <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits maxId)
     name <- case props & IntMap.lookup pid of
         Nothing -> fail ("could not find property name for property id " ++ show pid)
         Just x -> pure x
@@ -675,8 +675,8 @@ getFloat maxValue numBits = do
     let maxBitValue = (Bits.shiftL 1 (numBits - 1)) - 1
     let bias = Bits.shiftL 1 (numBits - 1)
     let serIntMax = Bits.shiftL 1 numBits
-    delta <- getFloatDelta serIntMax
-    let unscaledValue = delta - bias
+    delta <- fmap CompressedWord.fromCompressedWord (BinaryBit.getBits serIntMax)
+    let unscaledValue = (delta :: Int) - bias
     if maxValue > maxBitValue
     then do
         let invScale = fromIntegral maxValue / fromIntegral maxBitValue
@@ -742,15 +742,3 @@ getInt7 = BinaryBit.getBits 7
 
 getBool :: Bits.BitGet Boolean.Boolean
 getBool = BinaryBit.getBits 0
-
-
-getFloatDelta :: Int -> Bits.BitGet Int
-getFloatDelta serIntMax = do
-    x <- BinaryBit.getBits serIntMax
-    x & CompressedWord.fromCompressedWord & pure
-
-
-getPropId :: Int -> Bits.BitGet Int
-getPropId maxId = do
-    x <- BinaryBit.getBits maxId
-    x & CompressedWord.fromCompressedWord & pure

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -675,7 +675,7 @@ getFloat maxValue numBits = do
     let maxBitValue = (Bits.shiftL 1 (numBits - 1)) - 1
     let bias = Bits.shiftL 1 (numBits - 1)
     let serIntMax = Bits.shiftL 1 numBits
-    delta <- getInt serIntMax
+    delta <- getFloatDelta serIntMax
     let unscaledValue = delta - bias
     if maxValue > maxBitValue
     then do
@@ -775,3 +775,9 @@ getInt7 = BinaryBit.getBits 7
 
 getBool :: Bits.BitGet Boolean.Boolean
 getBool = BinaryBit.getBits 0
+
+
+getFloatDelta :: Int -> Bits.BitGet Int
+getFloatDelta serIntMax = do
+    x <- BinaryBit.getBits serIntMax
+    x & CompressedWord.value & fromIntegral & pure

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -162,7 +162,7 @@ getNewReplication context actorId = do
     (classId, className) <- case CPM.getClass (contextObjectMap context) Data.classes (contextClassMap context) (Int32.fromInt32 objectId) of
         Nothing -> fail ("could not find class for object id " ++ show objectId)
         Just x -> pure x
-    classInit <- getInitialization className
+    classInit <- Initialization.getInitialization className
     let thing = Thing
             { thingFlag = unknownFlag
             , thingObjectId = objectId
@@ -621,27 +621,6 @@ extractContext replay =
         , replay & ReplayWithoutFrames.version2
         ] & map Word32.fromWord32 & Version.makeVersion
     }
-
-
-getInitialization :: StrictText.Text -> Bits.BitGet Initialization.Initialization
-getInitialization className = do
-    location <-
-        if Set.member className Data.classesWithLocation
-            then do
-                vector <- Vector.getIntVector
-                pure (Just vector)
-            else pure Nothing
-    rotation <-
-        if Set.member className Data.classesWithRotation
-            then do
-                vector <- Vector.getInt8Vector
-                pure (Just vector)
-            else pure Nothing
-    pure
-        Initialization.Initialization
-        { Initialization.location = location
-        , Initialization.rotation = rotation
-        }
 
 
 getInt32 :: Bits.BitGet Int32.Int32

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -25,7 +25,6 @@ import qualified Octane.Type.Float32 as Float32
 import qualified Octane.Type.Frame as Frame
 import qualified Octane.Type.Initialization as Initialization
 import qualified Octane.Type.Int32 as Int32
-import qualified Octane.Type.Int8 as Int8
 import qualified Octane.Type.KeyFrame as KeyFrame
 import qualified Octane.Type.List as List
 import qualified Octane.Type.Property as Property
@@ -624,23 +623,6 @@ extractContext replay =
     }
 
 
-getVectorBytewise
-    :: Bits.BitGet (Vector.Vector Int8.Int8)
-getVectorBytewise = do
-    hasX <- getBool
-    x <- if Boolean.unpack hasX then getInt8 else pure 0
-    hasY <- getBool
-    y <- if Boolean.unpack hasY then getInt8 else pure 0
-    hasZ <- getBool
-    z <- if Boolean.unpack hasZ then getInt8 else pure 0
-    pure
-        Vector.Vector
-        { Vector.x = x
-        , Vector.y = y
-        , Vector.z = z
-        }
-
-
 getInitialization :: StrictText.Text -> Bits.BitGet Initialization.Initialization
 getInitialization className = do
     location <-
@@ -652,7 +634,7 @@ getInitialization className = do
     rotation <-
         if Set.member className Data.classesWithRotation
             then do
-                vector <- getVectorBytewise
+                vector <- Vector.getInt8Vector
                 pure (Just vector)
             else pure Nothing
     pure
@@ -664,10 +646,6 @@ getInitialization className = do
 
 getInt32 :: Bits.BitGet Int32.Int32
 getInt32 = BinaryBit.getBits 0
-
-
-getInt8 :: Bits.BitGet Int8.Int8
-getInt8 = BinaryBit.getBits 0
 
 
 getWord64 :: Bits.BitGet Word64.Word64

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -627,7 +627,8 @@ extractContext replay =
 
 getVector :: Bits.BitGet (Vector.Vector Int)
 getVector = do
-    numBits <- getNumVectorBits
+    rawNumBits <- getNumVectorBits
+    let numBits = rawNumBits & CompressedWord.value & fromIntegral
     let bias = Bits.shiftL 1 (numBits + 1)
     let maxBits = numBits + 2
     let maxValue = 2 ^ maxBits
@@ -764,8 +765,8 @@ getActorId :: Bits.BitGet CompressedWord.CompressedWord
 getActorId = BinaryBit.getBits 1024
 
 
-getNumVectorBits :: Bits.BitGet Int
-getNumVectorBits = getInt 19
+getNumVectorBits :: Bits.BitGet CompressedWord.CompressedWord
+getNumVectorBits = BinaryBit.getBits 19
 
 
 getInt7 :: Bits.BitGet CompressedWord.CompressedWord

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -255,7 +255,7 @@ getProp context thing = do
         Nothing -> fail ("could not find property map for class id " ++ show classId)
         Just x -> pure x
     let maxId = props & IntMap.keys & (0 :) & maximum
-    pid <- getInt maxId
+    pid <- getPropId maxId
     name <- case props & IntMap.lookup pid of
         Nothing -> fail ("could not find property name for property id " ++ show pid)
         Just x -> pure x
@@ -780,4 +780,10 @@ getBool = BinaryBit.getBits 0
 getFloatDelta :: Int -> Bits.BitGet Int
 getFloatDelta serIntMax = do
     x <- BinaryBit.getBits serIntMax
-    x & CompressedWord.value & fromIntegral & pure
+    x & CompressedWord.fromCompressedWord & pure
+
+
+getPropId :: Int -> Bits.BitGet Int
+getPropId maxId = do
+    x <- BinaryBit.getBits maxId
+    x & CompressedWord.fromCompressedWord & pure

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -159,9 +159,11 @@ getNewReplication context actorId = do
     objectName <- case context & contextObjectMap & IntMap.lookup (Int32.fromInt32 objectId) of
         Nothing -> fail ("could not find object name for id " ++ show objectId)
         Just x -> pure x
-    (classId, className) <- case CPM.getClass (contextObjectMap context) Data.classes (contextClassMap context) (Int32.fromInt32 objectId) of
-        Nothing -> fail ("could not find class for object id " ++ show objectId)
-        Just x -> pure x
+    (classId, className) <- CPM.getClass
+        (contextObjectMap context)
+        Data.classes
+        (contextClassMap context)
+        (Int32.fromInt32 objectId)
     classInit <- Initialization.getInitialization className
     let thing = Thing
             { thingFlag = unknownFlag

--- a/library/Octane/Utility/Parser.hs
+++ b/library/Octane/Utility/Parser.hs
@@ -768,8 +768,8 @@ getNumVectorBits :: Bits.BitGet Int
 getNumVectorBits = getInt 19
 
 
-getInt7 :: Bits.BitGet Int
-getInt7 = getInt 7
+getInt7 :: Bits.BitGet CompressedWord.CompressedWord
+getInt7 = BinaryBit.getBits 7
 
 
 getBool :: Bits.BitGet Boolean.Boolean


### PR DESCRIPTION
This is one of the most used types in the replay files. Making a separate type for it makes it easier to prove that it's correct. It also makes it easier to benchmark.

A lot of things need to be switched over to using it. I started with the actor IDs because they were the lowest impact change.
