### PR TITLE
Support the "--version" flag

### DIFF
--- a/library/Octane.hs
+++ b/library/Octane.hs
@@ -3,9 +3,11 @@ module Octane
     , module Octane.Main
     , module Octane.Type
     , module Octane.Utility
+    , module Octane.Version
     ) where
 
 import Octane.Data
 import Octane.Main
 import Octane.Type
 import Octane.Utility
+import Octane.Version

--- a/library/Octane/Main.hs
+++ b/library/Octane/Main.hs
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Lazy as LazyBytes
 import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Client.TLS as TLS
 import qualified Octane.Type.Replay as Replay
+import qualified Octane.Version as Version
 import qualified System.Environment as Environment
 
 
@@ -38,6 +39,7 @@ main = do
     args <- Environment.getArgs
     case args of
         [] -> main0
+        ["--version"] -> mainVersion
         [x] -> main1 x
         xs -> main2 xs
 
@@ -47,6 +49,11 @@ main0 = do
     LazyBytes.interact (\ input -> do
         let replay = Binary.decode input
         Aeson.encode (replay :: Replay.Replay))
+
+
+mainVersion :: IO ()
+mainVersion = do
+    putStrLn Version.versionString
 
 
 main1 :: String -> IO ()

--- a/library/Octane/Version.hs
+++ b/library/Octane/Version.hs
@@ -1,0 +1,15 @@
+module Octane.Version (version, versionString) where
+
+import Data.Function ((&))
+
+import qualified Data.String as String
+import qualified Data.Version as Version
+import qualified Paths_octane as This
+
+
+version :: Version.Version
+version = This.version
+
+
+versionString :: (String.IsString string) => string
+versionString = version & Version.showVersion & String.fromString

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,7 @@ library:
   - text ==1.2.*
   - unordered-containers ==0.2.*
   - vector ==0.11.*
+  other-modules: Paths_octane
   source-dirs: library
 license: MIT
 license-file: LICENSE.markdown


### PR DESCRIPTION
This fixes #46.

```
> stack exec -- octane --version
0.14.0
```
